### PR TITLE
fix: 앱 배너 닫기 후 화면에 바로 반영되지 않던 버그 해결

### DIFF
--- a/src/js/includes/app-promotion.js
+++ b/src/js/includes/app-promotion.js
@@ -50,6 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     closeBannerBtn.addEventListener("click", () => {
         toggleDisplay(appBanner, false);
         localStorage.setItem("appBannerClosed", "true");
+        appBanner.dataset.shouldShow = "false";
         window.forceHeaderRecalculate?.(); // 헤더 위치 재조정
     });
 


### PR DESCRIPTION
### ✅ 변경 사항
- 앱 배너 닫기 버튼 클릭 시 `dataset.shouldShow` 값을 `"false"`로 명시적으로 설정하여, 닫힘 상태가 실시간으로 반영되도록 수정
- 스크롤 이벤트에서도 해당 값을 참조하여 배너가 다시 나타나지 않도록 처리

### 👀 확인 사항
- 앱 모달을 닫은 후 앱 배너가 정상적으로 노출되는지
- 앱 배너 닫기 버튼을 누르면 배너가 즉시 사라지고, 스크롤해도 다시 나타나지 않는지
- 새로고침해도 앱 배너가 숨겨진 상태가 유지되는지