### PR TITLE
feat : Home - InteriorFeed 반응형 구현 완료 (min-width: 768px)

### DIFF
--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -180,7 +180,6 @@ body {
 
 /* 인테리어 피드 - content */
 .feed-content {
-    width: calc(100% + 32px);
     margin-left: -16px;
 }
 
@@ -352,6 +351,12 @@ body {
 
 .grid-item:hover .feed-post-image {
     transform: scale(1.05);
+}
+
+@media (max-width: 767) {
+    .feed-content {
+        width: calc(100% + 32px);
+    }
 }
 
 /* 768px 이상의 화면에서 적용되는 스타일 */

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -555,4 +555,8 @@ body {
     .feed-more-link .feed-more:hover {
         opacity: 0.5;
     }
+
+    .feed-content .feed-post {
+        width: calc(98% - 12px);
+    }
 }

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -43,7 +43,7 @@ body {
     transform: scale(1.05);
 }
 
-#banner .button {
+#home .button {
     display: none;
 }
 
@@ -181,6 +181,7 @@ body {
 /* 인테리어 피드 - content */
 .feed-content {
     margin-left: -16px;
+    position: relative;
 }
 
 .feed-content .swiper-wrapper {
@@ -451,12 +452,15 @@ body {
         flex: 1;
     }
 
-    #banner-main .swiper-button-wrapper {
+    #home .swiper-button-wrapper {
         position: absolute;
         top: 50%;
         transform: translate(-50%, -50%);
         transition: opacity 0.2s ease-in-out;
         z-index: 1;
+    }
+
+    #banner-main .swiper-button-wrapper {
         opacity: 0;
     }
 
@@ -464,15 +468,15 @@ body {
         opacity: 1;
     }
 
-    #banner-main .prev-button-wrapper {
+    #home .prev-button-wrapper {
         left: 0%;
     }
 
-    #banner-main .next-button-wrapper {
+    #home .next-button-wrapper {
         left: 100%;
     }
 
-    #banner-main .button {
+    #home .button {
         width: 48px;
         height: 48px;
         font-weight: 700;
@@ -485,25 +489,25 @@ body {
         box-shadow: 0 2px 5px rgba(63, 71, 77, 0.15);
     }
 
-    #banner-main .button:hover,
+    #home .button:hover,
     .button:active {
         background-color: #f7f9fa;
     }
 
-    #banner-main .chevron-icon {
+    #home .chevron-icon {
         display: inline-block;
         font-size: 24px;
         line-height: 1;
         color: #2f3438;
     }
 
-    #banner-main .chevron-right::before {
+    #home .chevron-right::before {
         font-family: OhouseIcon;
         vertical-align: top;
         content: '\e96a';
     }
 
-    #banner-main .chevron-left::before {
+    #home .chevron-left::before {
         font-family: OhouseIcon;
         vertical-align: top;
         content: '\e966';
@@ -566,5 +570,9 @@ body {
 
     .feed-content .more-slide {
         padding-right: 16px;
+    }
+
+    #interior-feed .prev-button-wrapper {
+        margin-left: 16px;
     }
 }

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -565,7 +565,7 @@ body {
     }
 
     .feed-content .feed-post {
-        width: calc(98% - 12px);
+        width: calc(97.5% - 12px);
     }
 
     .feed-content .more-slide {

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -174,6 +174,10 @@ body {
     content: '\e976';
 }
 
+.feed-more-link .feed-more {
+    display: none;
+}
+
 /* 인테리어 피드 - content */
 .feed-content {
     width: calc(100% + 32px);
@@ -536,6 +540,7 @@ body {
     }
 
     .feed-more-link .feed-more {
+        display: block;
         font-size: 16px;
         line-height: 20px;
         font-weight: 700;

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -295,6 +295,10 @@ body {
     justify-content: center;
 }
 
+.feed-content .more-link:hover > div:first-of-type {
+    background-color: rgb(218, 221, 224);
+}
+
 .feed-content .more-icon {
     font-size: 18px;
 }
@@ -558,5 +562,9 @@ body {
 
     .feed-content .feed-post {
         width: calc(98% - 12px);
+    }
+
+    .feed-content .more-slide {
+        padding-right: 16px;
     }
 }

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -162,13 +162,13 @@ body {
     white-space: nowrap;
 }
 
-.feed-more .arrow-right-icon {
+.feed-more-link .arrow-right-icon {
     font-size: 24px;
     color: rgb(47, 52, 56);
     cursor: pointer;
 }
 
-.feed-more .arrow-right-icon::before {
+.feed-more-link .arrow-right-icon::before {
     font-family: OhouseIcon;
     vertical-align: top;
     content: '\e976';
@@ -519,5 +519,30 @@ body {
 
     .banner__swiper-pagination-desktop .plus-icon {
         font-size: 12px;
+    }
+
+    /* 인테리어 피드 */
+    #interior-feed {
+        padding: 0px 40px;
+        margin: 40px auto;
+    }
+
+    #home .section-divider {
+        display: none;
+    }
+
+    .feed-more-link .arrow-right-icon {
+        display: none;
+    }
+
+    .feed-more-link .feed-more {
+        font-size: 16px;
+        line-height: 20px;
+        font-weight: 700;
+        color: rgb(10, 165, 255);
+    }
+
+    .feed-more-link .feed-more:hover {
+        opacity: 0.5;
     }
 }

--- a/src/js/pages/community/home.js
+++ b/src/js/pages/community/home.js
@@ -1,7 +1,8 @@
 document.addEventListener('DOMContentLoaded', function () {
     const bannerImageList = []; // 배너 이미지 파일명을 저장할 리스트
     let isMobile = window.innerWidth < 768; // 현재 화면이 모바일인지 여부
-    let bannerSwiper;
+    let bannerSwiper; // 배너 Swiper 인스턴스
+    let interiorFeedSwiper; // 인테리어 피드 Swiper 인스턴스
 
     // 현재 화면 크기에 맞춰 배너 swiper를 초기화하거나 재설정하는 함수
     function initBannerSwiper() {
@@ -64,21 +65,38 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    initBannerSwiper(); // 최초 1회 초기화 실행
+    // 인테리어 피드 Swiper 초기화 함수
+    function initInteriorFeedSwiper() {
+        // 기존 인스턴스 제거
+        if (interiorFeedSwiper) {
+            interiorFeedSwiper.destroy(true, true);
+        }
 
-    // 창 크기 변경 감지 후 모바일/PC 구간이 달라지면 swiper 재초기화
+        const options = {
+            slidesPerView: isMobile ? 2.5 : 4,
+        };
+
+        if (isMobile) {
+            options.slidesOffsetAfter = 35;
+        }
+
+        interiorFeedSwiper = new Swiper('#interior-feed .swiper', options);
+    }
+
+    // 초기화 함수 실행 (최초 1회)
+    initBannerSwiper();
+    initInteriorFeedSwiper();
+
+    // 창 크기 변경 감지 → 모바일 ↔ PC 구간 변경 시 swiper 재초기화
     window.addEventListener('resize', () => {
         const currentIsMobile = window.innerWidth < 768;
-        if (currentIsMobile !== isMobile) {
-            isMobile = currentIsMobile; // 상태 업데이트
-            initBannerSwiper(); // 새로 초기화
-        }
-    });
 
-    // 인테리어 피드 Swiper 초기화
-    const interiorFeedSwiper = new Swiper('#interior-feed .swiper', {
-        slidesPerView: 2.5,
-        slidesOffsetAfter: 35,
+        // 모바일 여부가 바뀐 경우에만 재초기화
+        if (currentIsMobile !== isMobile) {
+            isMobile = currentIsMobile;
+            initBannerSwiper(); // 배너 Swiper 재초기화
+            initInteriorFeedSwiper(); // 인테리어 피드 Swiper도 재초기화
+        }
     });
 
     // 북마크 버튼 클릭 시 아이콘 토글

--- a/src/js/pages/community/home.js
+++ b/src/js/pages/community/home.js
@@ -72,8 +72,25 @@ document.addEventListener('DOMContentLoaded', function () {
             interiorFeedSwiper.destroy(true, true);
         }
 
+        // Swiper 이전/다음 버튼 요소 선택
+        const prevBtn = document.querySelector('.feed-button-prev');
+        const nextBtn = document.querySelector('.feed-button-next');
+
         const options = {
             slidesPerView: isMobile ? 2.5 : 4,
+            slidesPerGroup: 4,
+            navigation: {
+                prevEl: '.feed-button-prev',
+                nextEl: '.feed-button-next',
+            },
+            on: {
+                init: function () {
+                    updateNavButtons(this); // 초기 버튼 상태 설정
+                },
+                slideChange: function () {
+                    updateNavButtons(this); // 슬라이드 변경 시 버튼 상태 업데이트
+                },
+            },
         };
 
         if (isMobile) {
@@ -81,6 +98,23 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         interiorFeedSwiper = new Swiper('#interior-feed .swiper', options);
+
+        // 버튼 상태 업데이트 함수
+        function updateNavButtons(swiper) {
+            // 맨 처음 슬라이드면 이전 버튼 숨김
+            if (swiper.isBeginning) {
+                prevBtn.style.display = 'none';
+            } else {
+                prevBtn.style.display = '';
+            }
+
+            // 맨 끝 슬라이드면 다음 버튼 숨김
+            if (swiper.isEnd) {
+                nextBtn.style.display = 'none';
+            } else {
+                nextBtn.style.display = '';
+            }
+        }
     }
 
     // 초기화 함수 실행 (최초 1회)

--- a/src/pages/community/home.html
+++ b/src/pages/community/home.html
@@ -186,8 +186,9 @@
                         <a class="feed-title" href="#">이런 사진 찾고 있나요?</a>
                         <span class="feed-subtitle">좋아하실 만한 인테리어 콘텐츠를 추천해드려요</span>
                     </div>
-                    <a class="feed-more" href="#">
+                    <a class="feed-more-link" href="#">
                         <span class="arrow-right-icon"></span>
+                        <span class="feed-more">더보기</span>
                     </a>
                 </div>
 

--- a/src/pages/community/home.html
+++ b/src/pages/community/home.html
@@ -505,6 +505,17 @@
                             </div>
                         </div>
                     </div>
+                    <!-- swiper 버튼 -->
+                    <div class="prev-button-wrapper swiper-button-wrapper">
+                        <button class="button feed-button-prev" type="button">
+                            <span class="chevron-icon chevron-left"></span>
+                        </button>
+                    </div>
+                    <div class="next-button-wrapper swiper-button-wrapper">
+                        <button class="button feed-button-next" type="button">
+                            <span class="chevron-icon chevron-right"></span>
+                        </button>
+                    </div>
                 </div>
             </section>
             <hr class="section-divider" />


### PR DESCRIPTION
### ✅ 구현 사항
### 768px 이상
- `feed-header`의 '더보기 아이콘'을 **'더보기' 문자**로 변경
- `feed-content`의 `swiper-slide`를 **4개씩** 나열
- `swiper`의 **navigation 버튼** 추가



https://github.com/user-attachments/assets/33bf58f6-82a4-4c33-94b0-70fd07f3d422


### 👀 확인 사항
- **모바일 화면**에서 **데스크탑 화면**으로 전환될 때,
  - '더보기 아이콘'이 **'더보기' 문자**로 잘 변경 되는지 확인
    - `hover`시 **문자 색상** 변하는 것도 확인
  - `swiper-slide`의 **개수**가 잘 변경되는지 확인
  - `swiper` **버튼**이 잘 나타나는지, 잘 동작하는지 확인









