### PR TITLE
feat : Home - QuickMenu 반응형 구현 완료 (min-width: 768px)

### DIFF
--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -87,7 +87,7 @@ body {
     padding: 0 16px;
 }
 
-#quick-menu .grid-container {
+#quick-menu .quick-menu__container {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     margin-top: 16px;
@@ -536,6 +536,20 @@ body {
 
     .banner__swiper-pagination-desktop .plus-icon {
         font-size: 12px;
+    }
+
+    /* 퀵 메뉴 */
+    #quick-menu {
+        padding: 0 40px;
+    }
+
+    #quick-menu .quick-menu__container {
+        display: flex;
+        margin: 30px 0 40px;
+    }
+
+    #quick-menu .quick-menu__item {
+        flex: 1;
     }
 
     /* 인테리어 피드 */

--- a/src/pages/community/home.html
+++ b/src/pages/community/home.html
@@ -74,7 +74,7 @@
 
             <!-- 퀵 매뉴 -->
             <section id="quick-menu">
-                <div class="grid-container">
+                <div class="quick-menu__container">
                     <div class="quick-menu__item">
                         <a class="quick-menu__link" href="#">
                             <img

--- a/src/pages/community/home.html
+++ b/src/pages/community/home.html
@@ -150,9 +150,9 @@
                             <img
                                 class="quick-menu__icon"
                                 src="/src/assets/icons/quick-menu/fast-delivery-icon.png"
-                                alt="빠른배송"
+                                alt="원하는날도착"
                             />
-                            <span class="quick-menu__label">빠른배송</span>
+                            <span class="quick-menu__label">원하는날도착</span>
                         </a>
                     </div>
                     <div class="quick-menu__item">


### PR DESCRIPTION
### ✅ 구현 사항
### 768px 이상
- `quick-menu` 섹션의 레이아웃을 `grid` → **`flex`로 변경**하여 **한 줄 배치**
- 각 **퀵 메뉴 item**에 **`flex: 1` 적용**하여 균등 너비로 정렬

- 모바일
  <img width="482" alt="quick-menu(mobile)" src="https://github.com/user-attachments/assets/0385869f-ad4b-4edb-8e23-3f81415c439e" />

- 768px 이상
  <img width="686" alt="quick-menu(768px)" src="https://github.com/user-attachments/assets/20dc6d40-731f-487d-a5f0-79fbbe4fb8b7" />

https://github.com/user-attachments/assets/971f58ef-813e-4239-b08b-24aa49223df4

### 👀 확인 사항
- **모바일 화면**과 **데스크탑 화면** 전환 시,
  - **`quick-menu` 섹션의 레이아웃**이 `grid` ↔ `flex`로 잘 전환되는지 확인