### PR TITLE
feat: top-banner (web) 섹션 구현 완료

### DIFF
--- a/src/css/includes/top-banner.css
+++ b/src/css/includes/top-banner.css
@@ -1,0 +1,87 @@
+/*** top-banner.css ***/
+
+#top-banner {
+    position: relative;
+    display: none;
+    z-index: 1000;
+}
+
+.top-banner__link--left {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 50%;
+    background-color: #1496f4;
+    left: 0;
+}
+
+.top-banner__link--right {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 50%;
+    background-color: #1496f4;
+    right: 0;
+}
+
+#top-banner__wrapper {
+    display: flex;
+    max-width: 1156px;
+    margin: 0 auto;
+    padding: 0 40px;
+}
+
+.top-banner__link--center {
+    flex: 1 0 0;
+    background-image: url(https://image.ohou.se/i/bucketplace-v2-development/uploads/exhibitions/descriptions/170544879717314750.png);
+    background-color: #1496f4;
+    position: relative;
+    height: 50px;
+    background-size: auto 100%;
+    background-repeat: no-repeat;
+    background-position: center;
+    z-index: 1;
+}
+
+.top-banner__close-button {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    display: block;
+    margin: -25px 0 0;
+    padding: 12px;
+    color: white;
+    width: 48px;
+    height: 48px;
+    box-sizing: border-box;
+    font-size: 0;
+    line-height: 0;
+}
+
+._dismiss_thick_24 {
+    display: inline-block;
+    font-size: 24px;
+    line-height: 1;
+    color: #ffffff;
+}
+
+._dismiss_thick_24::before {
+    content: "\e9c6";
+}
+
+.top-banner__close-icon::before {
+    font-family: Ohouseicon;
+    vertical-align: top;
+}
+
+@media (min-width: 768px) {
+    #top-banner {
+        display: block;
+    }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -3,6 +3,7 @@
 @import url(./common/theme.css);
 
 @import url(/src/css/includes/app-promotion.css);
+@import url(/src/css/includes/top-banner.css);
 @import url(/src/css/includes/header.css);
 @import url(./pages/community/home.css);
 @import url(/src/css/includes/footer.css);

--- a/src/includes/header.html
+++ b/src/includes/header.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/src/css/main.css">
   <script src="/src/js/includes/header.js"></script>
   <script src="/src/js/includes/app-promotion.js"></script>
+  <script src="/src/js/includes/top-banner.js"></script>
 </head>
 
 <body>
@@ -55,6 +56,17 @@
         간편하게 로그인하기</div>
       <button class="appBanner__cta-btn">앱으로 보기</button>
     </div>
+  </div>
+  <!-- PC 최상단 배너 -->
+  <div id="top-banner">
+    <a aria-label="PC 최상단 배너" class="top-banner__link top-banner__link--left" href="/"></a>
+    <a aria-label="PC 최상단 배너" class="top-banner__link top-banner__link--right" href="/"></a>
+    <div id="top-banner__wrapper">
+      <a aria-label="PC 최상단 배너" class="top-banner__link top-banner__link--center" href="/"></a>
+    </div>
+    <button type="button" aria-label="닫기" class="top-banner__close-button">
+      <span class="_dismiss_thick_24 top-banner__close-icon"></span>
+    </button>
   </div>
   <!-- 헤더 -->
   <header>

--- a/src/js/includes/header.js
+++ b/src/js/includes/header.js
@@ -105,14 +105,27 @@ document.addEventListener("DOMContentLoaded", () => {
     // 초기 실행
     applyHeaderStyles();
     updateContainerHeights();
+    handleScroll(); // 초기 스크롤 위치에 맞게 설정
 
-    // 이벤트 등록
-    window.addEventListener("scroll", handleScroll);
+    // 리사이즈 이벤트 등록
     window.addEventListener("resize", () => {
+        const nowIsMobile = window.innerWidth < 768;
+
+        // 모바일 → PC 전환 시 topBanner 다시 보이게 설정
+        if (!nowIsMobile && isMobileView) {
+            topBanner.style.display = "";
+        }
+
+        // 뷰 상태 업데이트
+        isMobileView = nowIsMobile;
+
         applyHeaderStyles();       // 리사이즈 시 width 조정
         updateContainerHeights();  // 높이 다시 계산
         handleScroll();            // 스크롤 위치에 맞게 동작 반영
     });
+
+    // 스크롤 이벤트 등록
+    window.addEventListener("scroll", handleScroll);
 
 
     /*** 네비게이션창 ***/

--- a/src/js/includes/header.js
+++ b/src/js/includes/header.js
@@ -102,17 +102,19 @@ document.addEventListener("DOMContentLoaded", () => {
         lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
     }
 
+    let isMobileView = window.innerWidth < 768;
+    // 로컬스토리지 상태 확인 함수
+    const isTopBannerClosed = () => localStorage.getItem("topBannerClosed") === "true";
     // 초기 실행
     applyHeaderStyles();
     updateContainerHeights();
-    handleScroll(); // 초기 스크롤 위치에 맞게 설정
 
     // 리사이즈 이벤트 등록
     window.addEventListener("resize", () => {
         const nowIsMobile = window.innerWidth < 768;
 
-        // 모바일 → PC 전환 시 topBanner 다시 보이게 설정
-        if (!nowIsMobile && isMobileView) {
+        // 모바일 → PC 전환 시, 유저가 탑배너를 닫지 않았다면 다시 표시
+        if (!nowIsMobile && isMobileView && !isTopBannerClosed()) {
             topBanner.style.display = "";
         }
 

--- a/src/js/includes/header.js
+++ b/src/js/includes/header.js
@@ -3,6 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const headerWrapper = document.getElementById("header__wrapper");
     const subnavContainer = document.getElementById("subnav__container");
     const appBanner = document.getElementById("appBanner");
+    const topBanner = document.getElementById("top-banner");
 
     let lastScrollTop = 0; // 이전 스크롤 위치 저장용
 
@@ -40,58 +41,65 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    // 스크롤 이벤트 핸들러
     function handleScroll() {
         const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
         const isMobile = window.innerWidth < 768;
         const atTop = scrollTop <= 0;
-        const shouldShowBanner = appBanner.dataset.shouldShow === "true";
+        const shouldShowAppBanner = appBanner.dataset.shouldShow === "true";
 
+        // 모바일 처리
         if (isMobile) {
-            // 모바일: 헤더 + 서브네비 모두 fixed
+            // 모바일에서는 탑배너 강제 숨김
+            topBanner.style.display = "none";
+
             headerWrapper.classList.add("fixed");
             subnavContainer.classList.add("fixed");
 
             if (scrollTop > lastScrollTop) {
-                // 아래로 스크롤 시: 헤더/서브네비 숨김
+                // 아래로 스크롤
                 appBanner.style.display = "none";
                 headerWrapper.style.top = "-50.75px";
                 subnavContainer.style.top = "-40.75px";
             } else {
-                // 위로 스크롤 시
-                if (atTop && shouldShowBanner) {
-                    // 맨 위 + 배너 보여야 하면: 배너 표시
+                // 위로 스크롤
+                if (atTop && shouldShowAppBanner) {
+                    // 최상단 + 앱배너 표시 조건
                     appBanner.style.display = "flex";
                     headerWrapper.style.top = `${appBanner.offsetHeight}px`;
                     subnavContainer.style.top = `${appBanner.offsetHeight + 50.75}px`;
                 } else {
-                    // 일반적인 위로 스크롤
+                    // 일반 위로 스크롤
                     appBanner.style.display = "none";
                     headerWrapper.style.top = "0";
                     subnavContainer.style.top = "50.75px";
                 }
             }
-        } else {
-            // PC: 헤더는 고정, 서브네비만 움직임
+        }
+
+        // PC 처리
+        else {
             headerWrapper.classList.add("fixed");
             subnavContainer.classList.add("fixed");
 
-            headerWrapper.style.top = "0";
+            // 탑배너 표시 여부 확인
+            const isTopBannerVisible = getComputedStyle(topBanner).display !== "none";
+            const topBannerHeight = (isTopBannerVisible && atTop) ? topBanner.offsetHeight : 0;
 
             if (scrollTop > lastScrollTop) {
-                // 아래로 스크롤: 서브네비 살짝 위로
+                // 아래로 스크롤
+                headerWrapper.style.top = "0";
                 subnavContainer.style.top = "29px";
-
-                subnavDropdown.classList.remove('open', 'open-active');
+                subnavDropdown.classList.remove("open", "open-active");
             } else {
-                // 위로 스크롤: 서브네비 원위치
-                subnavContainer.style.top = "80.75px";
+                // 위로 스크롤
+                headerWrapper.style.top = `${topBannerHeight}px`;
+                subnavContainer.style.top = `${topBannerHeight + 80.75}px`;
             }
         }
 
-        applyHeaderStyles();      // width, padding-right 적용
-        updateContainerHeights(); // 높이 갱신
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // 스크롤 위치 저장
+        applyHeaderStyles();
+        updateContainerHeights();
+        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
     }
 
     // 초기 실행

--- a/src/js/includes/top-banner.js
+++ b/src/js/includes/top-banner.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+    /*** 요소 참조 ***/
+    const topBanner = document.querySelector("#top-banner");
+    const closeTopBannerBtn = document.querySelector(".top-banner__close-button");
+
+    /*** 상태 확인 함수 ***/
+    const isTopBannerClosed = () => localStorage.getItem("topBannerClosed") === "true";
+
+    /*** 표시 제어 함수 ***/
+    const toggleTopBanner = (show) => {
+        if (!topBanner) return;
+        topBanner.style.display = show ? "block" : "none";
+    };
+
+    /*** 초기화 ***/
+    const initTopBanner = () => {
+        const shouldShow = !isTopBannerClosed();
+        toggleTopBanner(shouldShow);
+    };
+
+    /*** 이벤트 리스너 ***/
+    closeTopBannerBtn?.addEventListener("click", () => {
+        toggleTopBanner(false);
+        localStorage.setItem("topBannerClosed", "true");
+    });
+
+    initTopBanner();
+});

--- a/src/js/includes/top-banner.js
+++ b/src/js/includes/top-banner.js
@@ -6,21 +6,19 @@ document.addEventListener('DOMContentLoaded', () => {
     /*** 상태 확인 함수 ***/
     const isTopBannerClosed = () => localStorage.getItem("topBannerClosed") === "true";
 
-    /*** 표시 제어 함수 ***/
-    const toggleTopBanner = (show) => {
-        if (!topBanner) return;
-        topBanner.style.display = show ? "block" : "none";
-    };
-
     /*** 초기화 ***/
     const initTopBanner = () => {
-        const shouldShow = !isTopBannerClosed();
-        toggleTopBanner(shouldShow);
+        if (!topBanner) return;
+        if (isTopBannerClosed()) {
+            topBanner.style.display = "none";
+        } else {
+            topBanner.style.display = ""; // CSS에 맡김
+        }
     };
 
     /*** 이벤트 리스너 ***/
     closeTopBannerBtn?.addEventListener("click", () => {
-        toggleTopBanner(false);
+        topBanner.style.display = "none";
         localStorage.setItem("topBannerClosed", "true");
     });
 


### PR DESCRIPTION
### ✅ 변경사항
**1. 최상단 웹 배너 (top-Banner)**
- localStorage에서 배너 표시 여부를 관리.
- 배너의 "X" 클릭 시 배너 숨기고, localStorage에 상태 저장하여 이후 페이지에서 다시 나타나지 않음.

**2. localStorage 사용**
- 배너의 상태(topBannerClosed)를 localStorage에 저장하여 페이지 리프레시 후에도 상태 유지.

https://github.com/user-attachments/assets/a291ae1e-f6dd-4f53-b2c0-0d99bad4ba65

---
### 👀 확인 사항
> localStorage 확인 방법 : 개발자 도구 -> Application 탭 -> 왼쪽 바 : Storage -> local Storage -> http ~
- PC 화면(768px) 기준으로 처음 페이지 접근 시 `top-Banner`가 화면에 표시되는지?
- `top-Banner`의 "X" 버튼 클릭 후 `localStroage` 안에 `topBannerClosed` 값이 `true`로 표시되는지?
  - 이후 새로고침에는 빈 화면이 나타나는지?

---
### ⭐ 이후 수정 사항
PC에서 모바일 화면으로 너비 변경 시 나타나는 오류 수정 (스크롤바 없는 상황)