### PR TITLE
feat : Home - Banner 반응형 구현 완료 (min-width: 1024px 및 1256px)

### DIFF
--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -625,3 +625,11 @@ body {
         line-height: 20px;
     }
 }
+
+/* 1256px 이상의 화면에서 적용되는 스타일 */
+@media (min-width: 1256px) {
+    #banner {
+        max-width: 1256px;
+        margin: 0 auto;
+    }
+}

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -451,6 +451,10 @@ body {
         flex: 1;
     }
 
+    #banner .swiper {
+        border-radius: 4px;
+    }
+
     #home .swiper-button-wrapper {
         position: absolute;
         top: 50%;

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -609,4 +609,19 @@ body {
     #banner-main {
         margin-left: 20px;
     }
+
+    #banner-preview .title {
+        font-size: 32px;
+        line-height: 42px;
+    }
+
+    #banner-preview .profile-image {
+        width: 24px;
+        height: 24px;
+    }
+
+    #banner-preview .profile-name {
+        font-size: 16px;
+        line-height: 20px;
+    }
 }

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -365,6 +365,10 @@ body {
 
 /* 768px 이상의 화면에서 적용되는 스타일 */
 @media (min-width: 768px) {
+    #home {
+        margin-top: 30px;
+    }
+
     /* 배너 */
     #banner {
         padding: 0 40px;

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -594,3 +594,15 @@ body {
         grid-template-columns: repeat(4, 1fr);
     }
 }
+
+/* 1024px 이상의 화면에서 적용되는 스타일 */
+@media (min-width: 1024px) {
+    /* 배너 */
+    #banner {
+        padding: 0 60px;
+    }
+
+    #banner-main {
+        margin-left: 20px;
+    }
+}


### PR DESCRIPTION
### ✅ 구현 사항
### 1024px 이상
- `banner` 레이아웃 변경
- `banner-preview` 텍스트와 프로필 이미지 크기 변경 
### 1256px 이상
- `banner` 최대 너비 설정 및 중앙 정렬
### +) 768px 이상
- `banner-main`의 `border-radius` 값 변경
- `home` 섹션의 `margin-top` 값 변경

https://github.com/user-attachments/assets/552251d4-edef-4c77-a7df-e7d7eb5fc272

### 👀 확인 사항
- `1024px` 이상 또는 `1256px` 이상으로 바뀔 때, 레이아웃이 잘 변경되는지 확인