### PR TITLE
feat : Home - QuickMenu 반응형 구현 완료 (min-width: 1024px 및 1256px)

### DIFF
--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -628,6 +628,21 @@ body {
         font-size: 16px;
         line-height: 20px;
     }
+
+    /* 퀵 메뉴 */
+    #quick-menu {
+        padding: 0 60px;
+    }
+
+    .quick-menu__icon {
+        max-width: 88px;
+    }
+
+    .quick-menu__label {
+        margin-top: 8px;
+        font-size: 16px;
+        line-height: 20px;
+    }
 }
 
 /* 1256px 이상의 화면에서 적용되는 스타일 */

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -647,7 +647,8 @@ body {
 
 /* 1256px 이상의 화면에서 적용되는 스타일 */
 @media (min-width: 1256px) {
-    #banner {
+    #banner,
+    #quick-menu {
         max-width: 1256px;
         margin: 0 auto;
     }


### PR DESCRIPTION
### 1024px 이상
- `quick-menu` 레이아웃 변경
- `quick-menu__icon`, `quick-menu__label` 크기 변경

### 1256px 이상
- `quick-menu` 최대 너비 설정 및 중앙 정렬

https://github.com/user-attachments/assets/b79d2055-fe0d-4b6f-bc1b-cfb37bfce6b7


### 👀 확인 사항
- `1024px` 이상 또는 `1256px` 이상으로 바뀔 때, 레이아웃이 잘 변경되는지 확인