### PR TITLE
feat : Home - InteriorFeed 반응형 구현 완료 (min-width: 1024px 및 1256px)

### DIFF
--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -197,7 +197,7 @@ body {
     border-radius: 4px;
     overflow: hidden;
     position: relative;
-    width: calc(100% - 12px);
+    margin-right: 12px;
     display: flex;
 }
 
@@ -357,8 +357,8 @@ body {
     transform: scale(1.05);
 }
 
-@media (max-width: 767) {
-    .feed-content {
+@media (max-width: 767px) {
+    #interior-feed .feed-content {
         width: calc(100% + 32px);
     }
 }
@@ -586,7 +586,7 @@ body {
     }
 
     .feed-content .feed-post {
-        width: calc(97.5% - 12px);
+        margin-right: 16px;
     }
 
     .feed-content .more-slide {
@@ -632,6 +632,10 @@ body {
     /* 인테리어 피드 */
     .home-feed {
         padding: 0px 60px;
+    }
+
+    .feed-content .feed-post {
+        margin-right: 20px;
     }
 }
 

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -628,6 +628,11 @@ body {
         font-size: 16px;
         line-height: 20px;
     }
+
+    /* 인테리어 피드 */
+    .home-feed {
+        padding: 0px 60px;
+    }
 }
 
 /* 1256px 이상의 화면에서 적용되는 스타일 */

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -629,15 +629,6 @@ body {
         line-height: 20px;
     }
 
-<<<<<<< HEAD
-    /* 인테리어 피드 */
-    .home-feed {
-        padding: 0px 60px;
-    }
-
-    .feed-content .feed-post {
-        margin-right: 20px;
-=======
     /* 퀵 메뉴 */
     #quick-menu {
         padding: 0 60px;
@@ -651,7 +642,15 @@ body {
         margin-top: 8px;
         font-size: 16px;
         line-height: 20px;
->>>>>>> 003d126a9c295bdf7946268cb3b3d0f26bb821a6
+    }
+
+    /* 인테리어 피드 */
+    .home-feed {
+        padding: 0px 60px;
+    }
+
+    .feed-content .feed-post {
+        margin-right: 20px;
     }
 }
 

--- a/src/css/pages/community/home.css
+++ b/src/css/pages/community/home.css
@@ -645,4 +645,9 @@ body {
         max-width: 1256px;
         margin: 0 auto;
     }
+
+    /* 인테리어 피드 */
+    .home-feed {
+        max-width: 1256px;
+    }
 }

--- a/src/js/pages/community/home.js
+++ b/src/js/pages/community/home.js
@@ -77,11 +77,21 @@ document.addEventListener('DOMContentLoaded', function () {
         const nextBtn = document.querySelector('.feed-button-next');
 
         const options = {
-            slidesPerView: isMobile ? 2.5 : 4,
-            slidesPerGroup: 4,
+            slidesPerView: 2.5, // 기본값 (모바일 기준)
+            slidesPerGroup: 2,
             navigation: {
                 prevEl: '.feed-button-prev',
                 nextEl: '.feed-button-next',
+            },
+            breakpoints: {
+                768: {
+                    slidesPerView: 4,
+                    slidesPerGroup: 4,
+                },
+                1024: {
+                    slidesPerView: 6,
+                    slidesPerGroup: 6,
+                },
             },
             on: {
                 init: function () {


### PR DESCRIPTION
### 1024px 이상
- `home-feed` 레이아웃 변경
- `feed-post`의 `margin-right` 설정
- `slidesPerView`와 `slidesPerGroup` 값 6으로 변경

### 1256px 이상
- `home-feed` 최대 너비 설정

https://github.com/user-attachments/assets/598a73c1-b96d-4cac-ad6f-ad9f6ebae37e


### 👀 확인 사항
- `1024px` 이상 또는 `1256px` 이상으로 바뀔 때, 레이아웃이 잘 변경되는지 확인
- `1024px` 이상에서 6개씩 잘 나타나는지, 버튼을 눌렀을 때 6개씩 넘어가는지 확인

### ⭐ 이후 수정 사항
- **터치스크린 화면에서 원래 페이지와 다른 부분(swiper 버튼이 없어야 함, 넘길 때 하나씩 넘어가야 함) 등은 추후에 수정** 할 예정이니 일단 무시하고 확인 부탁드립니다