### PR TITLE
feat: Home - Header, Footer 반응형 구현 완료 (min-width: 1024px, max-width: 1023px)

### DIFF
--- a/src/css/includes/footer.css
+++ b/src/css/includes/footer.css
@@ -390,3 +390,9 @@ footer {
         display: none;
     }
 }
+
+@media (min-width: 1024px) {
+    #footer__container {
+        padding: 0 60px;
+    }
+}

--- a/src/css/includes/header.css
+++ b/src/css/includes/header.css
@@ -1787,13 +1787,23 @@ header {
 }
 
 @media (max-width: 1023px) {
-
   #header__search__bar {
     display: none;
   }
 }
 
 @media (min-width: 1024px) {
+  #header__logo {
+    margin-right: 35px;
+  }
+
+  #header__top {
+    padding: 0 60px;
+  }
+
+  #subnav__wrapper {
+    padding: 0 60px;
+  }
 
   .header__write-text {
     margin-right: 6px;

--- a/src/css/includes/header.css
+++ b/src/css/includes/header.css
@@ -150,6 +150,21 @@ header {
   line-height: 0;
 }
 
+#header__search__bar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  flex: 1 1 0px;
+  min-width: 0;
+  margin-right: 9px;
+}
+
+.search__input-indicator {
+  display: flex;
+  align-items: center;
+}
+
 #header__search-btn {
   display: inline-block;
   margin: 0;
@@ -1558,6 +1573,10 @@ header {
   color: #C2C8CC;
 }
 
+#search__input-container input {
+  width: 100%;
+}
+
 .search__icon {
   display: inline-block;
   font-size: 24px;
@@ -1767,6 +1786,13 @@ header {
   }
 }
 
+@media (max-width: 1023px) {
+
+  #header__search__bar {
+    display: none;
+  }
+}
+
 @media (min-width: 1024px) {
 
   .header__write-text {
@@ -1775,5 +1801,9 @@ header {
 
   .header__write-icon {
     display: inline-block;
+  }
+
+  #header__search__btn {
+    display: none;
   }
 }

--- a/src/css/includes/top-banner.css
+++ b/src/css/includes/top-banner.css
@@ -85,3 +85,9 @@
         display: block;
     }
 }
+
+@media (min-width: 1024px) {
+    #top-banner__wrapper {
+        padding: 0 60px;
+    }
+}

--- a/src/includes/header.html
+++ b/src/includes/header.html
@@ -99,7 +99,17 @@
 
           <div id="header__actions">
             <div id="header__actions-wrapper">
-              <div id="header__search">
+              <div id="header__search__bar">
+                <div id="search__combobox" role="combobox" aria-expanded="false" aria-haspopup="listbox">
+                  <div id="search__input-container">
+                    <span class="_search_24 search__icon"></span>
+                    <input id="search__input" type="text" placeholder="통합검색" autocomplete="off" aria-autocomplete="list"
+                      value="">
+                    <div class="search__input-indicator"></div>
+                  </div>
+                </div>
+              </div>
+              <div id="header__search__btn">
                 <button id="header__search-btn">
                   <span class="_search_24 header__search-btn-icon"></span>
                 </button>


### PR DESCRIPTION
### ✅ 변경사항
**1. header 영역에 검색 바 추가 (header__search__bar)**

**2. header와 footer 영역에 반응형 미디어쿼리 적용 (min-width: 1024px, max-width: 1023px)**

https://github.com/user-attachments/assets/87d5b767-bb38-4056-b893-7a06e47962b4

https://github.com/user-attachments/assets/276eac4f-8b54-4da3-97ef-d5db9cc1582f

---
### 👀 확인 사항
1. 최대 1023px 일 때
- header 영역 안에서 header__search__bar가 잘 나타나는지 ?
- footer 영역의 레이아웃이 제대로 변경되는지?
2. 최소 1024px 일 때
- header 영역의 양쪽 패딩 값이 제대로 적용되는지? (40->60 으로 값이 커지게 설정함)
- header 영역 안에서 header__search__btn이 사라지는지?
- 글쓰기 버튼의 화살표 아이콘이 제대로 표시되는지?

---
### ⭐ 이후 수정 사항
- 글쓰기 드롭박스, subnav 드롭박스, 실시간 검색어 드롭박스의 위치값 수정