### PR TITLE
feat: Home - Header, Footer 반응형 구현 완료 (min-width: 1256px, max-width: 1255px)

### DIFF
--- a/src/css/includes/footer.css
+++ b/src/css/includes/footer.css
@@ -299,25 +299,6 @@ footer {
     color: #656E75;
 }
 
-@media (max-width: 1023px) {
-    #footer__container {
-        grid-template-columns: 1fr 1px 1fr;
-        grid-row-gap: 24px;
-    }
-
-    #footer__divider-bottom {
-        grid-column-start: 1;
-        grid-column-end: 4;
-        width: 100%;
-        height: 1px;
-    }
-
-    #footer__bottom {
-        grid-column-start: 1;
-        grid-column-end: 4;
-    }
-}
-
 @media (min-width: 768px) {
     #footer__container {
         padding: 0 40px;
@@ -388,5 +369,42 @@ footer {
 
     .footer__certification {
         display: none;
+    }
+}
+
+@media (max-width: 1023px) {
+    #footer__container {
+        grid-template-columns: 1fr 1px 1fr;
+        grid-row-gap: 24px;
+    }
+
+    #footer__divider-bottom {
+        grid-column-start: 1;
+        grid-column-end: 4;
+        width: 100%;
+        height: 1px;
+    }
+
+    #footer__bottom {
+        grid-column-start: 1;
+        grid-column-end: 4;
+    }
+}
+
+@media (min-width: 1024px) {
+    #footer__container {
+        padding: 0 60px;
+    }
+}
+
+@media (min-width: 1256px) {
+    #footer__container {
+        max-width: 1256px;
+        margin: 0 auto;
+        padding: 0 60px;
+    }
+
+    #footer__operating-hours {
+        padding-right: 10px;
     }
 }

--- a/src/css/includes/header.css
+++ b/src/css/includes/header.css
@@ -1783,3 +1783,21 @@ header {
     display: none;
   }
 }
+
+@media (min-width: 1256px) {
+  #header__top {
+    max-width: 1256px;
+    margin: 0 auto;
+    padding: 0 60px;
+  }
+
+  #header__search__bar {
+    margin-right: 14px;
+  }
+
+  #subnav__wrapper {
+    max-width: 1256px;
+    margin: 0 auto;
+    padding: 0 60px;
+  }
+}

--- a/src/css/includes/header.css
+++ b/src/css/includes/header.css
@@ -1840,28 +1840,8 @@ header {
     margin: 0 auto;
     padding: 0 60px;
   }
-}
 
-@media (max-width: 1255px) {
-  .header__menu-link:nth-child(3) {
-    display: none;
-  }
-}
-
-@media (min-width: 1256px) {
-  #header__top {
-    max-width: 1256px;
-    margin: 0 auto;
-    padding: 0 60px;
-  }
-
-  #header__search__bar {
-    margin-right: 14px;
-  }
-
-  #subnav__wrapper {
-    max-width: 1256px;
-    margin: 0 auto;
-    padding: 0 60px;
+  #header__actions {
+    flex: 0 1 650px;
   }
 }

--- a/src/css/includes/header.css
+++ b/src/css/includes/header.css
@@ -1777,3 +1777,9 @@ header {
     display: inline-block;
   }
 }
+
+@media (max-width: 1255px) {
+  .header__menu-link:nth-child(3) {
+    display: none;
+  }
+}

--- a/src/includes/header.html
+++ b/src/includes/header.html
@@ -113,6 +113,7 @@
                 <div id="header__menu-links">
                   <a class="header__menu-link" href="/">로그인</a>
                   <a class="header__menu-link" href="/">회원가입</a>
+                  <a class="header__menu-link" href="/">고객센터</a>
                 </div>
                 <span id="header__write">
                   <button type="button" class="header__write-btn">


### PR DESCRIPTION
### ✅ 변경사항
**1. header__menu-link에 고객센터 요소 추가**

**2. header와 footer 영역에 반응형 미디어쿼리 적용 (min-width: 1256px, max-width: 1255px)**

---
### 👀 확인 사항
1. max-width: 1255px
- header 영역 안에서 고객센터 요소가 제대로 표시되는지?

2. min-width: 1256px
- 통합검색바의 너비가 잘 늘어나는지?
- 이후 화면 너비를 더 늘려도 기존 요소들에 영향을 미치지 않는지?